### PR TITLE
Fix poker Two Pair, Full House and Four of a Kind checking

### DIFF
--- a/src/main/kotlin/me/melijn/melijnbot/commands/games/PokerCommand.kt
+++ b/src/main/kotlin/me/melijn/melijnbot/commands/games/PokerCommand.kt
@@ -248,10 +248,11 @@ class PokerCommand : AbstractCommand("command.poker") {
             flush = true
         }
 
+        val occurrenceSorted = ranksOccurrenceMap.values.sortedDescending()
         if (ranksOccurrenceMap.size <= 2) {
-            if (ranksOccurrenceMap.values.sorted()[0] == 4) { // 4 of a  kind
+            if (occurrenceSorted[0] == 4) { // 4 of a  kind
                 return PokerHand("Four of a Kind", 7f)
-            } else if (ranksOccurrenceMap.values.sorted()[0] == 3) { // Full house
+            } else if (occurrenceSorted[0] == 3) { // Full house
                 return PokerHand("Full House", 5f)
             }
         }
@@ -281,7 +282,7 @@ class PokerCommand : AbstractCommand("command.poker") {
             return PokerHand("Straight", 50f)
         }
 
-        if (ranksOccurrenceMap.size == 3 && ranksOccurrenceMap.values.sorted()[0] == 2 && ranksOccurrenceMap.values.sorted()[1] == 2) { // Two Pair
+        if (ranksOccurrenceMap.size == 3 && occurrenceSorted[0] == 2 && occurrenceSorted[1] == 2) { // Two Pair
             return PokerHand("Two Pair", 2f)
         }
 
@@ -293,4 +294,3 @@ class PokerCommand : AbstractCommand("command.poker") {
         val multiplier: Float
     )
 }
-


### PR DESCRIPTION
Poker currently computes a map of rank occurrences and sorts its values _ascending_ in order to check for full house, four of a kind, ...

That means that for a hand like (2,2,2,3,3), the sorted list is (2,3). Unfortunately the first value out of that list is checked for equality with `3` for full house, while it should be the other way around. This PR fixes that behaviour by sorting the list in descending order instead, allowing players to win mel with two pair, full house and four of a kind.